### PR TITLE
解决web直传无法上传大于1G文件

### DIFF
--- a/src/OssAdapter.php
+++ b/src/OssAdapter.php
@@ -114,12 +114,13 @@ class OssAdapter extends AbstractAdapter
      * @param string $prefix
      * @param null   $callBackUrl
      * @param int    $expire
+     * @param int    $contentLengthRangeValue 最大文件大小
      *
      * @return false|string
      *
      * @throws \Exception
      */
-    public function signatureConfig($prefix = '', $callBackUrl = null, $expire = 30)
+    public function signatureConfig($prefix = '', $callBackUrl = null, $expire = 30,  $contentLengthRangeValue = 1048576000)
     {
         if (!empty($prefix)) {
             $prefix = ltrim($prefix, '/');
@@ -141,7 +142,7 @@ class OssAdapter extends AbstractAdapter
         $condition = [
             0 => 'content-length-range',
             1 => 0,
-            2 => 1048576000,
+            2 => $contentLengthRangeValue,
         ];
         $conditions[] = $condition;
 

--- a/src/Plugins/SignatureConfig.php
+++ b/src/Plugins/SignatureConfig.php
@@ -37,6 +37,6 @@ class SignatureConfig extends AbstractPlugin
      */
     public function handle($prefix = '', $callBackUrl = null, $expire = 30, $contentLengthRangeValue = 1048576000)
     {
-        return $this->filesystem->getAdapter()->signatureConfig($prefix, $callBackUrl, $expire, $contentLengthRangeValue = 1048576000);
+        return $this->filesystem->getAdapter()->signatureConfig($prefix, $callBackUrl, $expire, $contentLengthRangeValue);
     }
 }

--- a/src/Plugins/SignatureConfig.php
+++ b/src/Plugins/SignatureConfig.php
@@ -31,11 +31,12 @@ class SignatureConfig extends AbstractPlugin
      * @param string $prefix
      * @param null   $callBackUrl
      * @param int    $expire
+     * @param int    $contentLengthRangeValue
      *
      * @return mixed
      */
-    public function handle($prefix = '', $callBackUrl = null, $expire = 30)
+    public function handle($prefix = '', $callBackUrl = null, $expire = 30, $contentLengthRangeValue = 1048576000)
     {
-        return $this->filesystem->getAdapter()->signatureConfig($prefix, $callBackUrl, $expire);
+        return $this->filesystem->getAdapter()->signatureConfig($prefix, $callBackUrl, $expire, $contentLengthRangeValue = 1048576000);
     }
 }


### PR DESCRIPTION
`iidestiny/flysystem-oss/src/OssAdapter.php` 140行注释 // 最大文件大小.用户可以自己设置
但没提供更改的方法，所以我添加了一个参数，用来设置content-length-range的大小（最大上传文件大小）