### PR TITLE
切换Bucket之后客户端未重新初始化

### DIFF
--- a/src/OssAdapter.php
+++ b/src/OssAdapter.php
@@ -150,9 +150,7 @@ class OssAdapter extends AbstractAdapter
      */
     protected function initClient()
     {
-        if (empty($this->client)) {
-            $this->client = new OssClient($this->accessKeyId, $this->accessKeySecret, $this->endpoint, $this->isCName, ...$this->params);
-        }
+        $this->client = new OssClient($this->accessKeyId, $this->accessKeySecret, $this->endpoint, $this->isCName, ...$this->params);
     }
 
     /**


### PR DESCRIPTION
切换Bucket之后客户端未重新初始化，导致切换Bucket之后Client的配置依然是切换之前的配置