### PR TITLE
Fix PHP Deprecated:  Using ${var} in strings is deprecated

### DIFF
--- a/src/OssAdapter.php
+++ b/src/OssAdapter.php
@@ -246,7 +246,7 @@ class OssAdapter implements FilesystemAdapter
         } else {
             foreach ($systemData as $key => $value) {
                 if (!in_array($value, self::SYSTEM_FIELD)) {
-                    throw new \InvalidArgumentException("Invalid oss system filed: ${value}");
+                    throw new \InvalidArgumentException("Invalid oss system filed: {$value}");
                 }
                 $system[$key] = $value;
             }


### PR DESCRIPTION
PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead