### PR TITLE
Fix PHP8.1 Deprecated:Passing null to parameter #1 ($datetime) of typ…

### DIFF
--- a/src/Traits/SignatureTrait.php
+++ b/src/Traits/SignatureTrait.php
@@ -23,6 +23,6 @@ trait SignatureTrait
     public function gmt_iso8601($time)
     {
         // fix bug https://connect.console.aliyun.com/connect/detail/162632
-        return (new \DateTime(null, new \DateTimeZone('UTC')))->setTimestamp($time)->format('Y-m-d\TH:i:s\Z');
+        return (new \DateTime('', new \DateTimeZone('UTC')))->setTimestamp($time)->format('Y-m-d\TH:i:s\Z');
     }
 }


### PR DESCRIPTION
Fix PHP8.1 Deprecated:DateTime::__construct(): Passing null to parameter #1 ($datetime) of type string is deprecated