### PR TITLE
getTemporaryUrl 的 timeout 参数新增支持 DateTime 实例类型

### DIFF
--- a/src/OssAdapter.php
+++ b/src/OssAdapter.php
@@ -382,9 +382,10 @@ class OssAdapter implements FilesystemAdapter
      *
      * @return false|string
      */
-    public function getTemporaryUrl(string $path, int $timeout, array $options = [], string $method = OssClient::OSS_HTTP_GET): bool|string
+    public function getTemporaryUrl(string $path, $timeout, array $options = [], string $method = OssClient::OSS_HTTP_GET): bool|string
     {
         $path = $this->prefixer->prefixPath($path);
+        $timeout = $timeout instanceof \DateTimeInterface ? $timeout->getTimestamp() - time() : (int) $timeout;
 
         try {
             $path = $this->client->signUrl($this->bucketName, $path, $timeout, $method, $options);


### PR DESCRIPTION
在适配 laravel 时，参考文档示例通常传递 Carbon 时间对象，作此修改以支持更丰富的场景。

https://laravel.com/docs/12.x/filesystem#temporary-urls

### 临时URL

使用 `temporaryUrl` 方法，您可以创建使用 `local` 和 `s3` 驱动存储的文件的临时 URL。此方法接受一个路径和一个 `DateTime` 实例，指定 URL 应该在何时过期：

```php
use Illuminate\Support\Facades\Storage;

$url = Storage::temporaryUrl(
    'file.jpg', now()->addMinutes(5)
);
```