### PR TITLE
feat: verify 支持传参以支持常驻进程模式无法通过 $_SERVER 获取参数的情况

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,11 +1,13 @@
 * text=auto
 
 /tests export-ignore
+.editorconfig export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
 .scrutinizer.yml export-ignore
 .travis.yml export-ignore
 phpunit.php export-ignore
 phpunit.xml.dist export-ignore
+phpunit.xml.dist.bak export-ignore
 phpunit.xml export-ignore
 .php_cs export-ignore

--- a/src/OssAdapter.php
+++ b/src/OssAdapter.php
@@ -229,7 +229,14 @@ class OssAdapter implements FilesystemAdapter
     }
 
     /**
-     * 验签.
+     * Callback 验签
+     *
+     * @doc https://help.aliyun.com/zh/oss/developer-reference/callback
+     * @param  string  $authorizationBase64 Base64 编码的签名
+     * @param  string  $pubKeyUrlBase64 Base64 编码的公钥 URL
+     * @param  string  $path 请求路径
+     * @param  string  $body 请求体
+     * @return array
      */
     public function verify($authorizationBase64 = '', $pubKeyUrlBase64 = '', $path = '', $body = ''): array
     {

--- a/src/OssAdapter.php
+++ b/src/OssAdapter.php
@@ -231,11 +231,11 @@ class OssAdapter implements FilesystemAdapter
     /**
      * 验签.
      */
-    public function verify(): array
+    public function verify($authorizationBase64 = '', $pubKeyUrlBase64 = '', $path = '', $body = ''): array
     {
         // oss 前面 header、公钥 header
-        $authorizationBase64 = $_SERVER['HTTP_AUTHORIZATION'] ?? '';
-        $pubKeyUrlBase64 = $_SERVER['HTTP_X_OSS_PUB_KEY_URL'] ?? '';
+        $authorizationBase64 = $authorizationBase64 ?: $_SERVER['HTTP_AUTHORIZATION'] ?? '';
+        $pubKeyUrlBase64 = $pubKeyUrlBase64 ?: $_SERVER['HTTP_X_OSS_PUB_KEY_URL'] ?? '';
         // 验证失败
         if (empty($authorizationBase64) || empty($pubKeyUrlBase64)) {
             return [false, ['CallbackFailed' => 'authorization or pubKeyUrl is null']];
@@ -255,9 +255,9 @@ class OssAdapter implements FilesystemAdapter
         }
 
         // 获取回调 body
-        $body = file_get_contents('php://input');
+        $body = $body ?: file_get_contents('php://input');
         // 拼接待签名字符串
-        $path = $_SERVER['REQUEST_URI'];
+        $path = $path ?: $_SERVER['REQUEST_URI'] ?? '';
         $pos = strpos($path, '?');
         if (false === $pos) {
             $authStr = urldecode($path)."\n".$body;


### PR DESCRIPTION
## 存在问题

当前验证签名方法的代码来自 [官方 SDK][1]，其中的主要参数取自 `$_SERVER`；
在使用 [Laravel Octane][2] / [Laravel-s][3] 等常驻进程模式时，`$_SERVER` 是部分可读的；
因此，验证签名方法无法获取到正确的参数。

![image](https://github.com/user-attachments/assets/a9dcf66c-c540-487f-8f79-1570c1cd15b9)

## 解决方案

为验证签名方法添加传参，优先使用传入参数，没有传参时再使用原获取方式。

```php
/**
 * @param  string  $authorizationBase64 Base64 编码的签名
 * @param  string  $pubKeyUrlBase64 Base64 编码的公钥 URL
 * @param  string  $path 请求路径
 * @param  string  $body 请求体
 * @return array
 */
public function verify($authorizationBase64 = '', $pubKeyUrlBase64 = '', $path = '', $body = ''): array
{
    //
}
```

[1]:https://help.aliyun.com/zh/oss/developer-reference/callback
[2]:https://laravel.com/docs/master/octane
[3]:https://github.com/hhxsv5/laravel-s/blob/PHP-8.x/README-CN.md#%E8%AF%BB%E5%8F%96%E8%AF%B7%E6%B1%82