### PR TITLE
Adding prefix to path in readStream method

### DIFF
--- a/src/OssAdapter.php
+++ b/src/OssAdapter.php
@@ -770,6 +770,7 @@ class OssAdapter implements FilesystemAdapter
      */
     public function readStream(string $path)
     {
+        $path = $this->prefixer->prefixPath($path);
         $stream = fopen('php://temp', 'w+b');
 
         try {


### PR DESCRIPTION
The [`read`](https://github.com/iiDestiny/flysystem-oss/blob/9b5d1104f460b8593984d6fa7f927e5b9f06b6bd/src/OssAdapter.php#L756)  method adds prefix to path, but the [`readStream`](https://github.com/iiDestiny/flysystem-oss/blob/master/src/OssAdapter.php#L771C21-L784)  method doesn't.