### PR TITLE
修改 directoryExists 方法实现方式，用检测目录下是否有文件的方式检测目录是否存在

### DIFF
--- a/src/OssAdapter.php
+++ b/src/OssAdapter.php
@@ -732,7 +732,14 @@ class OssAdapter implements FilesystemAdapter
      */
     public function directoryExists(string $path): bool
     {
-        return $this->client->doesObjectExist($this->bucketName, $this->prefixer->prefixDirectoryPath($path));
+        $directory = $this->prefixer->prefixDirectoryPath($path);
+
+        foreach ($this->listContents($directory, false) as $item) {
+            // 只要有对象，则目录视为存在
+            return true;
+        }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
OSS 本质上是扁平存储，没有真正的文件夹。
要想检测「目录」是否存在，实际是检测指定前缀下是否存在文件。

<https://help.aliyun.com/zh/oss/user-guide/manage-directories>